### PR TITLE
Add possibility to silence printf output in Python

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,65 @@
+# Generated from CLion C/C++ Code Style settings
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignOperands: DontAlign
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Never
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 0
+CompactNamespaces: false
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PointerAlignment: Right
+ReflowComments: false
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 4

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@
     * [General Information](#general-information)
     * [Setting up a Virtual Environment](#setting-up-a-virtual-environment)
     * [Using CMake to build the Python package](#using-cmake-to-build-the-python-package)
-  * [CS_MoCo_LAB License](#cs_moco_lab-license)
+  * [CS_MoCo_LAB License](#csmocolab-license)
 <!-- TOC -->
 
 This repository provides a Python interface for the Poisson subsampling
@@ -40,6 +40,8 @@ class PoissonSampling:
     elliptical_mask: bool = True
     power: float = 2.0
     root: float = 2.0
+    random_seed: int = 0
+    logging: bool = False
 ```
 
 Therefore, a simple usage of the sampling is done by importing the package, create a `PoissonSampling`
@@ -61,6 +63,12 @@ from subsample import PoissonSampling
 my_dict = {"width" : 10, "height": 20}
 mask = PoissonSampling(**my_dict).subsample()
 ```
+### Notes
+
+- The `random_seed` property is intended for debugging/development where you need to fix the outcome of the random
+  number generator. A value different from zero will be used as an initialization seed.
+- The `logging` switch will turn off the debugging `printf` calls coming from the calculation algorithm and which would
+  appear in the Python console.
 
 ## Building and Installation
 

--- a/include/PoissonSubsampling.h
+++ b/include/PoissonSubsampling.h
@@ -3,35 +3,21 @@
 
 /**
  * Samples an elliptical region according to a Poisson distribution
- * @param lLines
- * @param lPartitions
- * @param dAccel
- * @param fully_sampled
- * @param pF_val
- * @param pFx
- * @param lPhases
- * @param v_type
- * @param s_type
- * @param ellipticalMask
- * @param p
- * @param n
- * @param body_part
- * @param iso_fac
- * @param random_seed If greater than zero, then this value is used for initialization the random generator.
- * @return
+ * Argument documentation can be found in the Python interface.
  */
 SamplingMask poissonSubsampling(long lLines,
-								long lPartitions,
-								float dAccel,
-								float fully_sampled,
-								float pF_val,
-								bool pFx,
-								int lPhases,
-								short int v_type,
-								short int s_type,
-								bool ellipticalMask,
-								float p,
-								float n,
-								short int body_part,
-								float iso_fac,
-								unsigned int random_seed);
+                                long lPartitions,
+                                float dAccel,
+                                float fully_sampled,
+                                float pF_val,
+                                bool pFx,
+                                int lPhases,
+                                short int v_type,
+                                short int s_type,
+                                bool ellipticalMask,
+                                float p,
+                                float n,
+                                short int body_part,
+                                float iso_fac,
+                                unsigned int random_seed,
+                                bool logging);

--- a/include/StdoutRedirector.h
+++ b/include/StdoutRedirector.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <cstdio>
+
+/**
+ * Provides a way to temporarily redirect stdout into the nirvana to silence printf messages in the library code.
+ * Note that this (probably) only silences printf calls and not C++ output with cout.
+ */
+class StdoutRedirector
+{
+public:
+    /**
+     * Turn on/off redirection of stdout. This function call should always come on pairs
+     * where you must not forget to turn redirection off after your done.
+     *
+     * @param redirect Turn on (true) or off (false)
+     *
+     * @note
+     */
+    static void redirectStdout(bool redirect);
+
+    StdoutRedirector(const StdoutRedirector &) = delete;
+    StdoutRedirector &operator=(const StdoutRedirector &) = delete;
+    StdoutRedirector(StdoutRedirector &&) = delete;
+    StdoutRedirector &operator=(StdoutRedirector &&) = delete;
+
+private:
+    StdoutRedirector() = default;
+    static bool isRedirecting;
+    static int oldStdout;
+};

--- a/interfaces/python/src/PythonInterface.cpp
+++ b/interfaces/python/src/PythonInterface.cpp
@@ -24,7 +24,8 @@ PYBIND11_MODULE(subsample_python_library, m)
 			  bool ellipticalMask,
 			  float p,
 			  float n,
-			  unsigned int random_seed
+			  unsigned int random_seed,
+			  bool logging
 		  )
 		  {
 			  return poissonSubsampling(
@@ -42,7 +43,8 @@ PYBIND11_MODULE(subsample_python_library, m)
 				  n,
 				  0,
 				  1.0,
-				  random_seed);
+				  random_seed,
+				  logging);
 		  },
 		  py::kw_only(),
 		  py::arg("width"),
@@ -57,7 +59,8 @@ PYBIND11_MODULE(subsample_python_library, m)
 		  py::arg("elliptical_mask"),
 		  py::arg("power"),
 		  py::arg("root"),
-		  py::arg("random_seed")
+		  py::arg("random_seed"),
+		  py::arg("logging")
 	);
 
 	py::class_<SamplingMask>(m, "SamplingMask", py::buffer_protocol())

--- a/interfaces/python/subsample/__init__.py.in
+++ b/interfaces/python/subsample/__init__.py.in
@@ -29,6 +29,7 @@ class PoissonSampling:
        power (float): Power of variable-density scaling [1:5]
        root (float): Root of variable-density scaling [1:5]
        random_seed (int): Explicit random seed to use. Automatic if 0.
+       logging (bool): Log to Python console
     """
     width: int = 256
     height: int = 128
@@ -43,6 +44,7 @@ class PoissonSampling:
     power: float = 2.0
     root: float = 2.0
     random_seed: int = 0
+    logging: bool = False
 
     def subsample(self) -> SamplingMask:
         return np.array(pd_sampling(**asdict(self)))

--- a/src/Approx.cpp
+++ b/src/Approx.cpp
@@ -3993,7 +3993,7 @@ bool Approx::checkMask(bool flag_autoTest, VDSamplingUpper *poiSamp, short int m
 		// increase min_dist approximately
 		step = (fabs(range[1] - range[0])) / 2;
 		min_dist = min_dist + step;
-		cout << "\nnew min_dist: " << min_dist << endl;
+		printf("\nnew min_dist: %f\n", min_dist);
 		poiSamp->setMin_dist(min_dist);
 	}
 	else if (min_dist_status == 2) {   // min_dist too large --> decrease min_dist

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(subsample_library
         SubsampleMain.cpp
         VariableDensity.cpp
         VDSamplingUpper.cpp
+        StdoutRedirector.cpp
         )
 
 target_include_directories(subsample_library

--- a/src/PoissonSubsampling.cpp
+++ b/src/PoissonSubsampling.cpp
@@ -1,157 +1,164 @@
 #include "../include/PoissonSubsampling.h"
 
-#include <string>
 #include <stdexcept>
+#include <string>
 
-#include "../include/VariableDensity.h"
-#include "../include/Approx.h"
-#include "../include/VDSamplingUpper.h"
-#include "../include/SamplingMask.h"
+#include "Approx.h"
+#include "StdoutRedirector.h"
+#include "VariableDensity.h"
 
 SamplingMask poissonSubsampling(long lLines,
-								long lPartitions,
-								float dAccel,
-								float fully_sampled,
-								float pF_val,
-								bool pFx,
-								int lPhases,
-								short int v_type,
-								short int s_type,
-								bool ellipticalMask,
-								float p,
-								float n,
-								short int body_part,
-								float iso_fac,
-								unsigned int random_seed)
+                                long lPartitions,
+                                float dAccel,
+                                float fully_sampled,
+                                float pF_val,
+                                bool pFx,
+                                int lPhases,
+                                short int v_type,
+                                short int s_type,
+                                bool ellipticalMask,
+                                float p,
+                                float n,
+                                short int body_part,
+                                float iso_fac,
+                                unsigned int random_seed,
+                                bool logging)
 {
 
-	// If the random_seed argument is non-zero, we use that for initializing the random seed, otherwise
-	// the current system time seconds are used.
-	if (random_seed > 0) {
-		srand(random_seed);
-	} else {
-		time_t seconds;
-		time(&seconds);
-		srand((unsigned) seconds);
-	}
+    // If the random_seed argument is non-zero, we use that for initializing the random seed, otherwise
+    // the current system time seconds are used.
+    if (random_seed > 0) {
+        srand(random_seed);
+    }
+    else {
+        time_t seconds;
+        time(&seconds);
+        srand((unsigned) seconds);
+    }
 
-	// flags
-	bool flag_first = true;              // fix first point on/off
-	bool flag_autoTest = true;          // automatic test if min_dist is too small or not on/off
+    // flags
+    bool flag_first = true;   // fix first point on/off
+    bool flag_autoTest = true;// automatic test if min_dist is too small or not on/off
 
-	// important parameters
-	//vd_options vd_op;
-	long nX = lLines;                        // image height [px] y-direction
-	long nY = lPartitions;                    // image width [px] z-direction
-	float M = dAccel;                        // downsampling factor
-	short int vd_type = v_type;              // type of variable density map
-	short int smpl_type = s_type;          // type of sampling
-	float pF_value = pF_val;              // applies partial fourier to the poisson disk sampling
-	bool pF_x = pFx;                      // orientation of the partial fourier
-	bool ellip_mask = ellipticalMask;
-	short int body_region = body_part;
-	SamplingMask
-		samplingMask{static_cast<size_t>(lPartitions), static_cast<size_t>(lLines), static_cast<size_t>(lPhases)};
+    // logging:
 
-	int nPointsToTest = 20;  // determine how many points are generated/tested around one point
-	float deviation = float(0.95);    // set maximal allowed deviation from undersampling factor
+    // important parameters
+    //vd_options vd_op;
+    long nX = lLines;            // image height [px] y-direction
+    long nY = lPartitions;       // image width [px] z-direction
+    float M = dAccel;            // downsampling factor
+    short int vd_type = v_type;  // type of variable density map
+    short int smpl_type = s_type;// type of sampling
+    float pF_value = pF_val;     // applies partial fourier to the poisson disk sampling
+    bool pF_x = pFx;             // orientation of the partial fourier
+    bool ellip_mask = ellipticalMask;
+    short int body_region = body_part;
+    SamplingMask
+        samplingMask{static_cast<size_t>(lPartitions), static_cast<size_t>(lLines), static_cast<size_t>(lPhases)};
 
-	float min_dist = M;                  // minimal distance around point in which no other point is allowed to be
-	short int min_dist_status;    // 0 = undefined, 1 = too small, 2 = too large, 3 = best approx, 4 = done
+    int nPointsToTest = 20;       // determine how many points are generated/tested around one point
+    float deviation = float(0.95);// set maximal allowed deviation from undersampling factor
 
-	if ((vd_type == 3 || vd_type == 4) && fully_sampled > float(1 / M)) {
-		throw std::domain_error("Number of fully_sampled-region-points is higher then the number of points to create.");
-	}
-	if (body_region != 0 && vd_type == 1) {
-		throw std::invalid_argument("Variable Density Type can't be 1 in an a priori mask");
-	}
+    float min_dist = M;       // minimal distance around point in which no other point is allowed to be
+    short int min_dist_status;// 0 = undefined, 1 = too small, 2 = too large, 3 = best approx, 4 = done
 
-	long nY_helper = nY;                  // is '1' if 2D-Sampling is activated
-	if (nY_helper == 1) // force 2D-Sampling
-	{
-		smpl_type = 0;
-	}
+    if ((vd_type == 3 || vd_type == 4) && fully_sampled > float(1 / M)) {
+        throw std::domain_error("Number of fully_sampled-region-points is higher then the number of points to create.");
+    }
+    if (body_region != 0 && vd_type == 1) {
+        throw std::invalid_argument("Variable Density Type can't be 1 in an a priori mask");
+    }
 
-	// 2D-Sampling - options
-	if (smpl_type == 0) {
-		nY_helper = 1;
-		ellip_mask = false;
-		vd_type = 0;
-	}
-		// 3D-Sampling - options
-	else {
-		if (vd_type == 0) {
-			throw std::invalid_argument("Variable Density Type can't be 0 in a 3D - Sampling Mask");
-		}
-	}
+    long nY_helper = nY;// is '1' if 2D-Sampling is activated
+    if (nY_helper == 1) // force 2D-Sampling
+    {
+        smpl_type = 0;
+    }
 
-	VariableDensity *vd = new VariableDensity(nX, nY_helper, vd_type, fully_sampled, ellip_mask, p, n, iso_fac, M);
+    // 2D-Sampling - options
+    if (smpl_type == 0) {
+        nY_helper = 1;
+        ellip_mask = false;
+        vd_type = 0;
+    }
+    // 3D-Sampling - options
+    else {
+        if (vd_type == 0) {
+            throw std::invalid_argument("Variable Density Type can't be 0 in a 3D - Sampling Mask");
+        }
+    }
 
-	if (vd_type < 6) {
-		min_dist =
-			Approx::findMinDistInLUT(nX, nY, M, fully_sampled, pF_value, vd_type, ellip_mask, p, iso_fac, smpl_type);
-	}
+    VariableDensity *vd = new VariableDensity(nX, nY_helper, vd_type, fully_sampled, ellip_mask, p, n, iso_fac, M);
 
-	// necessary parameters for approximation of min_dist
-	float step = 0;     // change of min_dist
+    if (vd_type < 6) {
+        StdoutRedirector::redirectStdout(true);
+        min_dist =
+            Approx::findMinDistInLUT(nX, nY, M, fully_sampled, pF_value, vd_type, ellip_mask, p, iso_fac, smpl_type);
+        StdoutRedirector::redirectStdout(false);
+    }
 
-	float *range;
-	if (smpl_type != 0) {// 3D
-		range = Approx::findRangeInLUT(nX, nY, M, fully_sampled, pF_value, vd_type, ellip_mask, p, iso_fac);
-	}
-	else {
-		range = new float[2];
-		range[0] = min_dist / 100;
-		range[1] = min_dist * 6;
-	}
+    // necessary parameters for approximation of min_dist
+    float step = 0;// change of min_dist
 
-	long nPointsMask = vd->genDensity();
+    float *range;
+    if (smpl_type != 0) {// 3D
+        StdoutRedirector::redirectStdout(true);
+        range = Approx::findRangeInLUT(nX, nY, M, fully_sampled, pF_value, vd_type, ellip_mask, p, iso_fac);
+        StdoutRedirector::redirectStdout(false);
+    }
+    else {
+        range = new float[2];
+        range[0] = min_dist / 100;
+        range[1] = min_dist * 6;
+    }
 
-	Approx *approx = new Approx(range, step);
+    long nPointsMask = vd->genDensity();
 
-	// generate Sampling object
-	VDSamplingUpper *poiSamp = new VDSamplingUpper{flag_first,
-												   vd_type,
-												   smpl_type,
-												   nX,
-												   nY_helper,
-												   M,
-												   pF_value,
-												   pF_x,
-												   min_dist,
-												   nPointsToTest,
-												   deviation,
-												   nPointsMask};
+    Approx *approx = new Approx(range, step);
 
-	for (size_t lPhase = 0; lPhase < lPhases; lPhase++) {
-		int loopcounter = 0;
-		bool failed = true;
+    // generate Sampling object
+    VDSamplingUpper *poiSamp = new VDSamplingUpper{flag_first,
+                                                   vd_type,
+                                                   smpl_type,
+                                                   nX,
+                                                   nY_helper,
+                                                   M,
+                                                   pF_value,
+                                                   pF_x,
+                                                   min_dist,
+                                                   nPointsToTest,
+                                                   deviation,
+                                                   nPointsMask};
+    StdoutRedirector::redirectStdout(true);
+    for (size_t lPhase = 0; lPhase < lPhases; lPhase++) {
+        int loopcounter = 0;
+        bool failed = true;
 
-		if (smpl_type == 1 && vd_type != 1)
-			poiSamp->genMaskWithFullySampledRegion(vd);
+        if (smpl_type == 1 && vd_type != 1)
+            poiSamp->genMaskWithFullySampledRegion(vd);
 
 
-		while (failed) {
-			// generate the sampling mask
-			min_dist_status = poiSamp->genSamplingMask(vd);
+        while (failed) {
+            // generate the sampling mask
+            min_dist_status = poiSamp->genSamplingMask(vd);
 
-			// check the sampling mask and optimize min_dist if necessary
-			// Note that flag_autoTest must be true so that it doesn't prompt the user.
-			failed = approx->checkMask(flag_autoTest, poiSamp, min_dist_status, vd);
+            // check the sampling mask and optimize min_dist if necessary
+            // Note that flag_autoTest must be true so that it doesn't prompt the user.
+            failed = approx->checkMask(flag_autoTest, poiSamp, min_dist_status, vd);
 
-			// too many iterations? --> stop loop
-			loopcounter++;
-			if (loopcounter == 150) {
-				failed = false;
-			}
-		}
+            // too many iterations? --> stop loop
+            loopcounter++;
+            if (loopcounter == 150) {
+                failed = false;
+            }
+        }
 
-		poiSamp->assignMaskSlice(samplingMask, lPhase);
-	}
+        poiSamp->assignMaskSlice(samplingMask, lPhase);
+    }
+    StdoutRedirector::redirectStdout(false);
+    delete poiSamp;
+    delete approx;
+    delete vd;
 
-	delete poiSamp;
-	delete approx;
-	delete vd;
-
-	return samplingMask;
+    return samplingMask;
 }

--- a/src/StdoutRedirector.cpp
+++ b/src/StdoutRedirector.cpp
@@ -1,0 +1,34 @@
+#include "StdoutRedirector.h"
+#include "unistd.h"
+#include <cstdio>
+#include <fcntl.h>
+#include <stdexcept>
+
+bool StdoutRedirector::isRedirecting = false;
+int StdoutRedirector::oldStdout = 0;
+
+void StdoutRedirector::redirectStdout(bool redirect)
+{
+    // Turn on redirecting stdout
+    if (redirect) {
+        if (isRedirecting) {
+            throw std::runtime_error("Already redirecting. Don't call it twice.");
+        }
+        fflush(stdout);
+        oldStdout = dup(1);
+        int newTarget = open("/dev/null", O_WRONLY);
+        dup2(newTarget, 1);
+        close(newTarget);
+        isRedirecting = true;
+    }
+    // Turn off redirecting stdout
+    else {
+        if (!isRedirecting) {
+            throw std::runtime_error("Don't turn off redirecting twice.");
+        }
+        fflush(stdout);
+        dup2(oldStdout, 1);
+        close(oldStdout);
+        isRedirecting = false;
+    }
+}

--- a/src/VDSamplingUpper.cpp
+++ b/src/VDSamplingUpper.cpp
@@ -248,8 +248,8 @@ void VDSamplingUpper::genMaskWithFullySampledRegion(VariableDensity *vd)
 
 	nSamplingMaskPointsHelper = nSamplingMaskPoints;
 
-	cout << "nSamplingMaskPointsHelper = " << nSamplingMaskPointsHelper << endl;
-	cout << "nElements = " << nElements << endl;
+	printf("nSamplingMaskPointsHelper = %ld\n", nSamplingMaskPointsHelper);
+	printf("nElements = %d\n", nElements);
 
 	for (int i = 0; i < nElements; i++)
 	{


### PR DESCRIPTION
I used an ugly hack to temporarily redirect `stdout` to `/dev/null` when calling library functions